### PR TITLE
fix queryAndMergeResults return values

### DIFF
--- a/SCQ_QueryProcessor.php
+++ b/SCQ_QueryProcessor.php
@@ -114,11 +114,7 @@ class SCQQueryProcessor extends SMWQueryProcessor {
 			$otherParams = parent::getProcessedParams( $otherParams, $printRequests );
 		}
 
-		return self::getResultFromQueryResult(
-			$queryResult,
-			$otherParams,
-			SMW_OUTPUT_WIKI
-		);
+		return array( $queryResult, $otherParams );
 	}
 
 	/**


### PR DESCRIPTION
@yaronkoren This change did not make it into your commits: https://github.com/wikimedia/mediawiki-extensions-SemanticCompoundQueries/pull/1/files#diff-b24b89d16098451f1fc1a80b15193751L87.

Old PR: https://github.com/wikimedia/mediawiki-extensions-SemanticCompoundQueries/pull/3