### PR TITLE
fix unsorted parameter

### DIFF
--- a/SCQ_QueryProcessor.php
+++ b/SCQ_QueryProcessor.php
@@ -105,7 +105,7 @@ class SCQQueryProcessor extends SMWQueryProcessor {
 		}
 
 		// Sort results so that they'll show up by page name
-		if( strcmp( $other_params['unsorted'], 'on' ) ) {
+		if( !isset($otherParams['unsorted']) || !strcmp( $otherParams['unsorted'], 'on' ) ) {
 			uasort( $results, array( 'SCQQueryProcessor', 'compareQueryResults' ) );
 		}
 

--- a/tests/phpunit/Unit/SCQ_CompoundQueryApiTest.php
+++ b/tests/phpunit/Unit/SCQ_CompoundQueryApiTest.php
@@ -91,16 +91,6 @@ class SCQCompoundQueryApiTest extends \PHPUnit_Framework_TestCase {
 				)
 			)
 		);
-		$provider['Invalid query, should produces an error'] = array(
-			array(
-				'[[Modification date::+!]];limit=3'
-			),
-			array(
-				array(
-					'error'=> 'foo',
-				)
-			)
-		);
 		return $provider;
 	}
 }

--- a/tests/phpunit/Unit/SCQ_QueryProcessorTest.php
+++ b/tests/phpunit/Unit/SCQ_QueryProcessorTest.php
@@ -69,7 +69,8 @@ class SCQQueryProcessorTest extends \PHPUnit_Framework_TestCase {
 			'[[don\'t;split',
 		];
 
-		$actual = $this->invokeMethod( new SCQQueryProcessor(), 'getSubParams', array( $param ) );
+		$processor = new SCQQueryProcessor();
+		$actual = $this->invokeMethod( $processor, 'getSubParams', array( $param ) );
 		$this->assertEquals( $expected, $actual );
 	}
 }


### PR DESCRIPTION
Just realized that the unsorted check was backwards! *facepalm*

Also fixed what @mwjames said in https://github.com/SemanticMediaWiki/SemanticCompoundQueries/commit/52d0ff14b40592968a228bd306c19bfac67fda23#commitcomment-18109326.