### PR TITLE
Fix dynamic property deprecation for display_options

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -12,6 +12,7 @@ skipped to align with SMW.
 * Minimum requirement for PHP raised to 8.1.
 * Minimum requirement for MediaWiki raised to 1.43.
 * Minimum requirement for Semantic MediaWiki raised to 7.0.
+* Fixed `Creation of dynamic property` deprecation notice on PHP 8.2 and later (#87).
 * Localization updates from https://translatewiki.net
 
 ## 3.0.0

--- a/src/CompoundQueryProcessor.php
+++ b/src/CompoundQueryProcessor.php
@@ -223,23 +223,8 @@ class CompoundQueryProcessor extends QueryProcessor {
 		}
 
 		$query = self::createQuery( $querystring, $params, $context, null, $extraPrintouts );
-		$queryResult = smwfGetStore()->getQueryResult( $query );
 
-		$parameters = [];
-
-		if ( version_compare( SMW_VERSION, '1.7.2', '>' ) ) {
-			foreach ( $params as $param ) {
-				$parameters[$param->getName()] = $param->getValue();
-			}
-		} else {
-			$parameters = $params;
-		}
-
-		foreach ( $queryResult->getResults() as $wikiPage ) {
-			$wikiPage->display_options = $parameters;
-		}
-
-		return $queryResult;
+		return smwfGetStore()->getQueryResult( $query );
 	}
 
 	/**

--- a/src/CompoundQueryResult.php
+++ b/src/CompoundQueryResult.php
@@ -34,9 +34,6 @@ class CompoundQueryResult extends QueryResult {
 		}
 
 		while ( ( $row = $newResult->getNext() ) !== false ) {
-			if ( property_exists( $newResult, 'display_options' ) ) {
-				$row[0]->display_options = $newResult->display_options;
-			}
 			$content = $row[0]->getContent();
 			$pageName = $content[0]->getLongText( SMW_OUTPUT_WIKI );
 


### PR DESCRIPTION
## Summary

Fixes #87.

On PHP 8.2 and later, rendering a page that uses `#compound_query` raises:

> Deprecated: Creation of dynamic property `SMW\DataItems\WikiPage::$display_options` is deprecated in `src/CompoundQueryProcessor.php`

`CompoundQueryProcessor::getQueryResultFromQueryString()` attached a `display_options` array to every SMW result data item. Writing an undeclared property on `SMW\DataItems\WikiPage` is what triggers the notice.

## Why removing it is correct

`display_options` is a leftover from old SMW, where result printers read display options off wiki-page *values*. In current Semantic MediaWiki nothing reads it:

- There is no reference to `display_options` anywhere in Semantic MediaWiki — no result printer, `ResultArray`, or data value consumes it.
- Its only reader in this extension was `CompoundQueryResult::addResult()`, which has no callers (and read the property off the `QueryResult` rather than the data item anyway).
- The merge path that actually runs — `queryAndMergeResults()` → `mergeSMWQueryResults()` → `new CompoundQueryResult( … )` — never touches it.
- No test depends on it.

Because nothing consumes the property, removing it produces identical rendered output. It also removes a latent fatal: the old code called `$queryResult->getResults()` unconditionally, which would error on a `format=debug` subquery (where `Store::getQueryResult()` returns a string).

## Changes

- `src/CompoundQueryProcessor.php` — remove the write loop and the `$parameters` block that existed only to feed it.
- `src/CompoundQueryResult.php` — remove the orphaned `display_options` reader in `addResult()`.
- `RELEASE-NOTES.md` — note the fix under 7.0.0.

## Testing

- `php -l` passes on both changed files.
- Confirmed no `display_options` references remain in the codebase.
- Full `composer analyze` / `composer test` not run locally; left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
