### PR TITLE
Remove obsolete SMW version checks

### DIFF
--- a/src/CompoundQueryProcessor.php
+++ b/src/CompoundQueryProcessor.php
@@ -117,10 +117,8 @@ class CompoundQueryProcessor extends QueryProcessor {
 
 		$queryResult = new CompoundQueryResult( $printRequests, new Query(), $results, smwfGetStore() );
 
-		if ( version_compare( SMW_VERSION, '1.6.1', '>' ) ) {
-			self::addThisPrintout( $printRequests, $otherParams );
-			$otherParams = self::getProcessedParams( $otherParams, $printRequests );
-		}
+		self::addThisPrintout( $printRequests, $otherParams );
+		$otherParams = self::getProcessedParams( $otherParams, $printRequests );
 
 		return [ $queryResult, $otherParams ];
 	}
@@ -217,10 +215,8 @@ class CompoundQueryProcessor extends QueryProcessor {
 	 * @return QueryResult
 	 */
 	protected static function getQueryResultFromQueryString( $querystring, array $params, $extraPrintouts, $context = QueryProcessor::INLINE_QUERY ) {
-		if ( version_compare( SMW_VERSION, '1.6.1', '>' ) ) {
-			QueryProcessor::addThisPrintout( $extraPrintouts, $params );
-			$params = self::getProcessedParams( $params, $extraPrintouts, false );
-		}
+		QueryProcessor::addThisPrintout( $extraPrintouts, $params );
+		$params = self::getProcessedParams( $params, $extraPrintouts, false );
 
 		$query = self::createQuery( $querystring, $params, $context, null, $extraPrintouts );
 
@@ -232,7 +228,7 @@ class CompoundQueryProcessor extends QueryProcessor {
 	 * except that formats of type 'debug' and 'count' aren't handled.
 	 *
 	 * @param CompoundQueryResult $res
-	 * @param array $params These need to be the result of a list fed to getProcessedParams as of SMW 1.6.2
+	 * @param array $params These need to be the result of a list fed to getProcessedParams
 	 * @param $outputmode
 	 * @param $context
 	 * @param string $format
@@ -240,15 +236,7 @@ class CompoundQueryProcessor extends QueryProcessor {
 	 * @return string
 	 */
 	protected static function getResultFromQueryResult( CompoundQueryResult $res, array $params, $outputmode, $context = QueryProcessor::INLINE_QUERY, $format = '' ) {
-		if ( version_compare( SMW_VERSION, '1.6.1', '>' ) ) {
-			$format = $params['format'];
-
-			if ( version_compare( SMW_VERSION, '1.7.2', '>' ) ) {
-				$format = $format->getValue();
-			}
-		} else {
-			$format = self::getResultFormat( $params );
-		}
+		$format = $params['format']->getValue();
 
 		$printer = self::getResultPrinter( $format, $context );
 		$result = $printer->getResult( $res, $params, $outputmode );


### PR DESCRIPTION
The extension now requires SemanticMediaWiki `>= 7.0` (see `extension.json`), so the `version_compare( SMW_VERSION, '1.6.1', '>' )` and `version_compare( SMW_VERSION, '1.7.2', '>' )` guards in `CompoundQueryProcessor` are always true on every supported version. This removes the dead branches and keeps the code paths that always executed:

- `queryAndMergeResults()` and `getQueryResultFromQueryString()`: unwrap the always-true `addThisPrintout()` / `getProcessedParams()` calls.
- `getResultFromQueryResult()`: collapse the format lookup to `$params['format']->getValue()` and drop the unreachable pre-1.6.1 `else` branch (which called `getResultFormat()`, no longer present in SMW 7.0).

This is dead-code removal only — no behavior change on any supported SMW version, so there is no release-notes entry.

The `!defined( 'SMW_VERSION' )` presence guard in `SemanticCompoundQueries.php` is intentionally left in place: it checks that Semantic MediaWiki is loaded at all, which is a different concern from the version comparisons removed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)