### PR TITLE
Use strict semantic versioning for the version number

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,13 +1,8 @@
 These are the RELEASE NOTES for the **Semantic Compound Queries** (a.k.a. SCQ) extension.
 
-## 7.0.0
+## 4.0.0
 
 Not yet released.
-
-Starting with this release, Semantic Compound Queries' major version tracks
-Semantic MediaWiki's major version. Subsequent releases follow the same
-convention. Versions 4.x through 6.x were never released and are intentionally
-skipped to align with SMW.
 
 * Minimum requirement for PHP raised to 8.1.
 * Minimum requirement for MediaWiki raised to 1.43.

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
 	},
 	"extra": {
 		"branch-alias": {
-			"dev-master": "7.x-dev"
+			"dev-master": "4.x-dev"
 		}
 	},
 	"config": {

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
 	"name": "SemanticCompoundQueries",
-	"version": "7.0.0-alpha",
+	"version": "4.0.0-alpha",
 	"author": [
 		"James Hong Kong",
 		"Yaron Koren",

--- a/src/Hooks.php
+++ b/src/Hooks.php
@@ -13,7 +13,7 @@ class Hooks implements ParserFirstCallInitHook {
 	/**
 	 * Registers the #compound_query parser function.
 	 *
-	 * @since 7.0.0
+	 * @since 4.0.0
 	 *
 	 * @param Parser $parser
 	 */


### PR DESCRIPTION
## Summary

Adopt semantic versioning for the **SemanticCompoundQueries** version number. Versioning the extension independently of Semantic MediaWiki lets it introduce its own breaking changes mid-cycle — between Semantic MediaWiki major releases — instead of holding them to realign its major with the next Semantic MediaWiki major.

This sets the version to the extension's own next major, `4.0.0-alpha` (branch-alias `4.x-dev`), rather than tracking the Semantic MediaWiki major. The `SemanticMediaWiki >= 7.0` requirement (the Semantic MediaWiki version this release targets) is unchanged.

## Changes

- `extension.json`: version → `4.0.0-alpha`
- `composer.json`: `extra.branch-alias.dev-master` → `4.x-dev`
- `RELEASE-NOTES.md`: heading → `4.0.0`, and drop the note that described the version tracking / mirroring the Semantic MediaWiki major
- `@since 7.0.0` docblocks updated to `@since 4.0.0` where present
