### PR TITLE
Restore per-sub-query map markers (#98)

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,11 @@
 These are the RELEASE NOTES for the **Semantic Compound Queries** (a.k.a. SCQ) extension.
 
+## 4.0.1
+
+* Restored per-sub-query map markers: the `icon` and `legend label` set on an
+  individual sub-query are shown again on Maps result formats. They had stopped
+  rendering in 4.0.0 (#98).
+
 ## 4.0.0
 
 Released on June 8, 2026.

--- a/src/CompoundQueryProcessor.php
+++ b/src/CompoundQueryProcessor.php
@@ -219,8 +219,39 @@ class CompoundQueryProcessor extends QueryProcessor {
 		$params = self::getProcessedParams( $params, $extraPrintouts, false );
 
 		$query = self::createQuery( $querystring, $params, $context, null, $extraPrintouts );
+		$queryResult = smwfGetStore()->getQueryResult( $query );
 
-		return smwfGetStore()->getQueryResult( $query );
+		self::attachDisplayOptions( $queryResult, $params );
+
+		return $queryResult;
+	}
+
+	/**
+	 * Attaches this sub-query's processed parameters to every result data item
+	 * as a `display_options` field, so result printers can apply options on a
+	 * per-sub-query basis. Semantic Maps reads this field to render the custom
+	 * marker (`icon`) and `legend label` configured for an individual
+	 * #compound_query sub-query.
+	 *
+	 * SMW's data items allow dynamic properties (since SMW 7.0, which is the
+	 * minimum requirement), so this assignment does not raise the PHP 8.2
+	 * dynamic-property deprecation that #87 addressed.
+	 *
+	 * @since 4.0.1
+	 *
+	 * @param QueryResult $queryResult
+	 * @param array $params Processed parameters; each entry exposes getName() and getValue()
+	 */
+	protected static function attachDisplayOptions( QueryResult $queryResult, array $params ): void {
+		$displayOptions = [];
+
+		foreach ( $params as $param ) {
+			$displayOptions[$param->getName()] = $param->getValue();
+		}
+
+		foreach ( $queryResult->getResults() as $dataItem ) {
+			$dataItem->display_options = $displayOptions;
+		}
 	}
 
 	/**

--- a/tests/phpunit/Unit/CompoundQueryProcessorTest.php
+++ b/tests/phpunit/Unit/CompoundQueryProcessorTest.php
@@ -5,6 +5,8 @@ namespace SCQ\Tests;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use SCQ\CompoundQueryProcessor;
+use SMW\DataItems\WikiPage;
+use SMW\Query\QueryResult;
 
 /**
  * @covers \SCQ\CompoundQueryProcessor
@@ -71,6 +73,56 @@ class CompoundQueryProcessorTest extends TestCase {
 		$processor = new CompoundQueryProcessor();
 		$actual = $this->invokeMethod( $processor, 'getSubParams', [ $param ] );
 		$this->assertEquals( $expected, $actual );
+	}
+
+	public function testAttachDisplayOptionsAddsOptionsToEveryResult() {
+		$alpha = new WikiPage( 'Alpha', NS_MAIN );
+		$beta = new WikiPage( 'Beta', NS_MAIN );
+
+		$queryResult = $this->getMockBuilder( QueryResult::class )
+			->disableOriginalConstructor()
+			->getMock();
+		$queryResult->method( 'getResults' )
+			->willReturn( [ $alpha, $beta ] );
+
+		$params = [
+			'icon' => $this->newProcessedParam( 'icon', 'Marker_Chartreuse.svg' ),
+			'format' => $this->newProcessedParam( 'format', 'leaflet' ),
+		];
+
+		$processor = new CompoundQueryProcessor();
+		$this->invokeMethod( $processor, 'attachDisplayOptions', [ $queryResult, $params ] );
+
+		$expected = [
+			'icon' => 'Marker_Chartreuse.svg',
+			'format' => 'leaflet',
+		];
+
+		$this->assertEquals( $expected, $alpha->display_options );
+		$this->assertEquals( $expected, $beta->display_options );
+	}
+
+	/**
+	 * Minimal stand-in for a ParamProcessor\ProcessedParam, exposing only the
+	 * getName()/getValue() accessors that attachDisplayOptions() relies on.
+	 */
+	private function newProcessedParam( string $name, string $value ): object {
+		return new class( $name, $value ) {
+
+			public function __construct(
+				private string $name,
+				private string $value
+			) {
+			}
+
+			public function getName(): string {
+				return $this->name;
+			}
+
+			public function getValue(): string {
+				return $this->value;
+			}
+		};
 	}
 
 }


### PR DESCRIPTION
## Problem

`#compound_query` lets each sub-query carry its own display parameters, including a per-sub-query map marker:

```
{{#compound_query:
  [[Har sidtyp::socken]] [[Har status::aktiv]] ;?Har koordinat ;icon=Marker_Chartreuse.svg
 |[[Har sidtyp::socken]] [[Har status::startgrop]] ;?Har koordinat ;icon=Marker_LightGrey.svg
 |format=leaflet
 ...
}}
```

After upgrading to SCQ 4.0 these custom markers stopped rendering — every result fell back to the default icon (#98).

## Cause

SCQ attaches each sub-query's processed parameters to its result data items as a `display_options` field. Maps reads that field in `QueryHandler::getLocationIcon()` to pick the `icon` (and `legend label`) for each marker:

```php
$display_location = $row[0]->getResultSubject();
if ( property_exists( $display_location, 'display_options' ) && is_array( $display_location->display_options ) ) {
    $icon = $display_location->display_options['icon'];
}
```

4.0.0 removed the only producer of that field (commit 33cc6fb, #87) on the premise that nothing read it. Maps does, so the markers disappeared.

## Fix

Restore the assignment, extracted into an `attachDisplayOptions()` helper so it can be unit tested. Each result data item again receives the sub-query's processed parameters as `display_options`, and Maps picks up the per-sub-query icon.

The PHP 8.2 dynamic-property deprecation that #87 set out to fix no longer applies: SCQ 4.x requires SMW >= 7.0, whose `DataItem` base class is marked `#[AllowDynamicProperties]`, so writing `display_options` to a result data item is deprecation-free under every supported configuration.

`CompoundQueryResult::addResult()` — the orphaned reader removed alongside the producer — stays removed; it has no callers.

## Testing

- New unit test `testAttachDisplayOptionsAddsOptionsToEveryResult` asserts every result data item receives the sub-query parameters as `display_options`.
- `composer analyze` (lint + PHPCS + minus-x) and `composer phpunit` (unit + integration, 63 tests) pass on MW 1.43 / SMW 7.x / PHP 8.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)