### PR TITLE
Prepare 4.0.1 release

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -2,6 +2,8 @@ These are the RELEASE NOTES for the **Semantic Compound Queries** (a.k.a. SCQ) e
 
 ## 4.0.1
 
+Released on June 26, 2026.
+
 * Restored per-sub-query map markers: the `icon` and `legend label` set on an
   individual sub-query are shown again on Maps result formats. They had stopped
   rendering in 4.0.0 (#98).

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
 	"name": "SemanticCompoundQueries",
-	"version": "4.0.0",
+	"version": "4.0.1",
 	"author": [
 		"James Hong Kong",
 		"Yaron Koren",


### PR DESCRIPTION
Prepares the 4.0.1 release.

- Bumps the extension version to `4.0.1`.
- Dates the `4.0.1` release notes.

This release restores per-sub-query map markers (the `icon` and `legend label` set on an individual `#compound_query` sub-query) on Maps result formats. They stopped rendering in 4.0.0 (#98) and were fixed in #99.